### PR TITLE
Filter Changes Already Voted On

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -50,7 +50,7 @@ jobs:
         GHPA_TOKEN: ${{ secrets.GHPA_TOKEN }}
       run: |
         ./ci/gerrit_changes_to_github.py \
-          --gerrit-api-url "https://review.spdk.io/gerrit/changes/?q=status:open+repo:spdk/spdk&o=CURRENT_REVISION" \
+          --gerrit-api-url "https://review.spdk.io/gerrit/changes/?q=status:open+repo:spdk/spdk&o=CURRENT_REVISION&o=MESSAGES" \
           --git-repository-path spdk \
           --git-remote-target-name origin \
           --git-remote-gerrit-name gerrit \


### PR DESCRIPTION
### Testing:
I have currently subbed in the account_id of the Mellanox Build Bot to test this. I have gone through the dispatch logs of this run: https://github.com/spdk-community-ci/dispatcher/actions/runs/11356587329/job/31588040422

I have logged the following situations (we can remove these logs before merging if they are not necessary):
We have a branch in the mirror for a specific change and:
    1. We have already voted on the current revision
    2. We have not voted yet on the current revision
    3. We have voted on a previous revision and it has been copied to the current revision
4. We do not have a branch for the change

I found an example of each of the logs and checked the corresponding patches on Gerrit to verify the above situations. For example the following log:
`Previous vote copied for change refs/changes/22/25222/2. Dropping`
corresponds to the following change:
https://review.spdk.io/gerrit/c/spdk/spdk/+/25222
which has a copied +1 vote from the Mellanox Build Bot from revision 1.

### Remaining TODO:
1. Change the `SAMSUNG_CI_ACCT_NUM` to the samsung bot's account_id
2. Investigate why linked run above dropped fewer changes than run based on main immediately after: https://github.com/spdk-community-ci/dispatcher/actions/runs/11356664976 (26 vs 31)
    - (Edit:) This actually makes sense because we make sure to append refs of revisions without a vote. Searching the logs we can see "Branch exists but no vote for change {ref} yet. Appending" appears 5 times.