### PR TITLE
Filter changes already voted on

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -50,7 +50,7 @@ jobs:
         GHPA_TOKEN: ${{ secrets.GHPA_TOKEN }}
       run: |
         ./ci/gerrit_changes_to_github.py \
-          --gerrit-api-url "https://review.spdk.io/gerrit/changes/?q=status:open+repo:spdk/spdk&o=CURRENT_REVISION" \
+          --gerrit-api-url "https://review.spdk.io/gerrit/changes/?q=status:open+repo:spdk/spdk+-label:Community-CI=ANY,user=spdk-community-ci-samsung&o=CURRENT_REVISION" \
           --git-repository-path spdk \
           --git-remote-target-name origin \
           --git-remote-gerrit-name gerrit \


### PR DESCRIPTION
I tested this by putting each "2024-10-17 09:51:21,505 - INFO - Got ref(refs/changes/XX/YYYY/ZZ) via REST API" log into a file after after this job: https://github.com/spdk-community-ci/dispatcher/actions/runs/11389667477/job/31689501023

Then I used a Python script to query for changes that have already been voted on using `url = 'https://review.spdk.io/gerrit/changes/?q=status:open+repo:spdk/spdk+label:Community-CI=ANY,user=spdk-community-ci-samsung&o=CURRENT_REVISION'`

Then I made sure that the refs/changes/... are mutually exclusive.

Attached is the script used. It opens a file called "logs.txt" that I pasted the "INFO - Got ref..." logs into.
[test.txt](https://github.com/user-attachments/files/17416545/test.txt)
