### PR TITLE
dispatch: pull 5 patches every 15 minutes

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -3,14 +3,14 @@ name: dispatch
 
 on:
   schedule:
-  - cron: '0 * * * *'
+  - cron: '*/15 * * * *'
 
   workflow_dispatch:
     inputs:
       limit:
         description: '--limit'
         required: false
-        default: 2 # If you change this, then also address CHANGES_LIMIT
+        default: 5 # If you change this, then also address CHANGES_LIMIT
 
 jobs:
   gerrit_to_github:
@@ -46,7 +46,7 @@ jobs:
 
     - name: Retrieve Changes from Gerrit, Push to GitHub and trigger!
       env:
-        CHANGES_LIMIT: ${{ github.event.inputs.limit || 2 }}
+        CHANGES_LIMIT: ${{ github.event.inputs.limit || 5 }}
         GHPA_TOKEN: ${{ secrets.GHPA_TOKEN }}
       run: |
         ./ci/gerrit_changes_to_github.py \


### PR DESCRIPTION
Patches currently take about 11-13 minutes to complete, so change the dispatch cadence to pull 5 patches every 15 minutes. We will leave it like this for a while, until the Samsung CI catches up with the open backlog of patches. We choose 5 patches because we have 5 runners currently.