### PR TITLE
gerrit_changes_to_github: don't fail when no remotes found

### DIFF
--- a/gerrit_changes_to_github.py
+++ b/gerrit_changes_to_github.py
@@ -191,7 +191,8 @@ def gerrit_changeinfo_via_rest_api(args) -> Optional[List[str]]:
 
             refs.append(str(ref))
 
-    if len(remotes) != 1:  # There should only be a single anonymous gerrit remote
+    # If there are changes, they should all be for a single anonymous gerrit remote
+    if len(remotes) > 1:
         log.error(f"Unexpected remotes({remotes})")
         return None
 


### PR DESCRIPTION
We won't find any remotes if there are no changes, so don't fail the script in that case.

Fixes issue #20.