### PR TITLE
autorun: handle hung autotest-unittest steps

### DIFF
--- a/.github/workflows/autorun.yml
+++ b/.github/workflows/autorun.yml
@@ -51,6 +51,7 @@ jobs:
 
   autorun_unittest:
     needs: source-archive
+    timeout-minutes: 15
     runs-on: [self-hosted, linux, x64, qemuhost]
     env:
       REPOSITORY_TARBALL_PATH: ${{ github.workspace }}/repository.tar.gz
@@ -135,12 +136,12 @@ jobs:
         PR_NUMBER=$(echo "${{ github.event.inputs.branch }}" | cut -d '/' -f 3)
         REV=$(echo "${{ github.event.inputs.branch }}" | cut -d '/' -f 4)
 
-        if [[ "${{ needs.autorun_unittest.result }}" == "failure" ]]; then
-          echo "One or more jobs failed."
-          VOTE=-1
-        else
+        if [[ "${{ needs.autorun_unittest.result }}" == "success" ]]; then
           echo "All jobs succeeded."
           VOTE=1
+        else
+          echo "One or more jobs failed."
+          VOTE=-1
         fi
 
         curl -X POST https://review.spdk.io/gerrit/a/changes/$PR_NUMBER/revisions/$REV/review \


### PR DESCRIPTION
The fix is two parts:

1) set autotest-unittest step timeout to 15 minutes, this cancels the
   autotest-unittest step
2) compare result against "success" when determining whether to vote
   +1 or -1; steps cancelled due to timeout or manual cancellation
   get a result of "cancelled", not "failure", so we can't check against
   "failure" only

Fixes issue #18.
Fixes issue #19.