### PR TITLE
Filter [RFC] Patches

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -50,7 +50,7 @@ jobs:
         GHPA_TOKEN: ${{ secrets.GHPA_TOKEN }}
       run: |
         ./ci/gerrit_changes_to_github.py \
-          --gerrit-api-url "https://review.spdk.io/gerrit/changes/?q=status:open+-age:6mon+repo:spdk/spdk+-label:Community-CI=ANY,user=spdk-community-ci-samsung&o=CURRENT_REVISION" \
+          --gerrit-api-url "https://review.spdk.io/gerrit/changes/?q=status:open+-age:6mon+repo:spdk/spdk+-label:Community-CI=ANY,user=spdk-community-ci-samsung+-%22%5BRFC%5D%22&o=CURRENT_REVISION" \
           --git-repository-path spdk \
           --git-remote-target-name origin \
           --git-remote-gerrit-name gerrit \


### PR DESCRIPTION
Adding `+-%22%5BRFC%5D%22` as a query parameter filters patches with "[RFC]" in the title.

`%22` is the percent encoding for `"`
`%5B` is the percent encoding for `[`
`%5D` is the percent encoding for `]`