### PR TITLE
autorun: use --fail-with-body when posting vote with curl

### DIFF
--- a/.github/workflows/autorun.yml
+++ b/.github/workflows/autorun.yml
@@ -147,4 +147,5 @@ jobs:
         curl -X POST https://review.spdk.io/gerrit/a/changes/$PR_NUMBER/revisions/$REV/review \
           -H "Content-Type: application/json" \
           -d "{ 'message': '$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID', 'labels': {'Community-CI': $VOTE}}" \
-          --user "spdk-community-ci-samsung:${{ secrets.GERRIT_PASSWORD }}"
+          --user "spdk-community-ci-samsung:${{ secrets.GERRIT_PASSWORD }}" \
+          --fail-with-body


### PR DESCRIPTION
Without this, Gerrit does a response, so curl just returns 0. But we want it to actually interpret the response, and exit with error for things like a 401 (Unauthorized).

Fixes issue #24.