### PR TITLE
Use events-log in dispatch workflow

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -52,9 +52,14 @@ jobs:
       env:
         CHANGES_LIMIT: ${{ github.event.inputs.limit || 5 }}
         GHPA_TOKEN: ${{ secrets.GHPA_TOKEN }}
+        GERRIT_PASSWORD: ${{ secrets.GERRIT_PASSWORD}}
+        LAST_TIMESTAMP: ${{ vars.LAST_TIMESTAMP}}
       run: |
         ./ci/gerrit_changes_to_github.py \
+          --gerrit-username "spdk-community-ci-samsung" \
           --gerrit-api-url "https://review.spdk.io/gerrit/changes/?q=status:open+-age:6mon+repo:spdk/spdk+-label:Community-CI=ANY,user=spdk-community-ci-samsung+-%22%5BRFC%5D%22&o=CURRENT_REVISION" \
+          --gerrit-events-log-url "https://review.spdk.io/a/plugins/events-log/events/" \
+          --gh-variables-url "https://api.github.com/repos/spdk-community-ci/dispatcher/actions/variables/" \
           --git-repository-path spdk \
           --git-remote-target-name origin \
           --git-remote-gerrit-name gerrit \


### PR DESCRIPTION
Example JSON event:
`{
        "submitter": {
            "name": "Atul Malakar",
            "email": "a.malakar@samsung.com",
            "username": "a-malakar"
        },
        "refUpdate": {
            "oldRev": "0000000000000000000000000000000000000000",
            "newRev": "3f7a579d208b5043b25cf0b2a99cdfa9efaf008b",
            "refName": "refs/changes/11/25311/2",
            "project": "spdk/spdk"
        },
        "type": "ref-updated",
        "eventCreatedOn": 1729766830
    },`

The given example is short, some events have more fields. 'events-log.json' attached below has more events.
[events-log.json](https://github.com/user-attachments/files/17593338/events-log.json)

Testing:
My test patch I commented "false positive" on at 10:48 PM PST: https://review.spdk.io/gerrit/c/spdk/spdk/+/25071
Picked up by dispatch workflow I ran immediately after: https://github.com/spdk-community-ci/dispatcher/actions/runs/11698670370/job/32579339698

`Using last timestamp (UTC): 2024-11-06 06:37:54
2024-11-06 06:57:06,358 - INFO - Saving last timestamp (UTC): 2024-11-06 06:57:06
2024-11-06 06:57:06,505 - INFO - Got 4 events.
2024-11-06 06:57:06,506 - INFO - 1 'false positives' found.`
