### PR TITLE
dispatch: limit to 1 concurrent job

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -19,6 +19,10 @@ jobs:
       contents: write
       actions: write
 
+    concurrency:
+      group: dispatcher
+      cancel-in-progress: false
+
     steps:
     - name: Change git config for GitHub Service Account
       run: |


### PR DESCRIPTION
To prevent race conditions when updating repository variables for event-fetching, ensure only a single instance of the 'dispatch' workflow can run at any given time.