### PR TITLE
fix(build_container): remove deprecated 'needs' from job

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   build-container:
-    needs: source-archive
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Removed lingering 'needs' dependency from the "build_images" job after splitting, as it is no longer required.