### PR TITLE
build_qcow2: use 'staging' in the image name during upload

### DIFF
--- a/.github/workflows/build_qcow2.yml
+++ b/.github/workflows/build_qcow2.yml
@@ -113,4 +113,4 @@ jobs:
         ./ci/s3_file_upload.py fedora_40_x86_64.qcow2 \
         --bucket "$S3_BUCKET" \
         --endpoint-url "$S3_ENDPOINT_URL" \
-        --object-key "system/fedora_40_x86_64.qcow2"
+        --object-key "system/fedora_40_x86_64.staging.qcow2"


### PR DESCRIPTION
Adding "staging" to the image name avoids accidental overwrites of currently in-use images by distinguishing recently built images from active ones.