### PR TITLE
build_*: limit concurrency to 1

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -14,6 +14,10 @@ jobs:
     env:
       IMAGE_ID: ghcr.io/${{ github.repository_owner }}/spdk-community-ci:poc
 
+    concurrency:
+      group: build_container
+      cancel-in-progress: false
+
     steps:
     - name: Checkout CI repository
       uses: actions/checkout@v4.1.7

--- a/.github/workflows/build_qcow2.yml
+++ b/.github/workflows/build_qcow2.yml
@@ -14,6 +14,10 @@ jobs:
   source-archive:
     runs-on: ubuntu-latest
 
+    concurrency:
+      group: build_qcow2
+      cancel-in-progress: false
+
     steps:
     - name: Checkout SPDK repository
       uses: actions/checkout@v4.1.7
@@ -54,6 +58,10 @@ jobs:
 
     env:
       REPOSITORY_TARBALL_PATH: ${{ github.workspace }}/repository.tar.gz
+
+    concurrency:
+      group: build_qcow2
+      cancel-in-progress: false
   
     steps:
     - name: Download the repository


### PR DESCRIPTION
Similar to the dispatch workflow, there is no reason for the build-docker and build-qcow2 workflows to run concurrently, as each job ultimately overwrites an image in ghcr.io or S3. Limiting concurrency to a single job prevents redundant resource usage, as multiple concurrent jobs would lead to unnecessary overwrites. Users should cancel any additional jobs if more than one is running to avoid wasting resources.