### PR TITLE
maintenance: add workflow that runs on all self-hosted runners

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,27 @@
+name: maintenance_selfhosted
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+  maintenance:
+    strategy:
+      matrix:
+        runner:
+        - eqnx_qemuhost00
+        - eqnx_qemuhost01
+        - eqnx_qemuhost02
+        - eqnx_qemuhost03
+        - eqnx_qemuhost04
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Get Runner Name
+        run: echo "This is running on runner ${{ runner.name }}"
+
+      - name: Maintenance Task
+        run: |
+          # Your maintenance script or commands
+          echo "Running maintenance on ${{ runner.name }}"


### PR DESCRIPTION
To perform maintenance tasks, such as removing cached .qcow2 images, on self-hosted runners. This workflow can be expanded in the future to accommodate additional tasks. It aims to ensure that maintenance tasks run on all self-hosted runners to modify their state as needed.