### PR TITLE
maintenace: run in the same container as autorun

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -17,6 +17,10 @@ jobs:
 
     runs-on: ${{ matrix.runner }}
 
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/spdk-community-ci:poc
+      options: --privileged
+
     steps:
       - name: Get Runner Name
         run: |
@@ -24,4 +28,7 @@ jobs:
 
       - name: Remove qcow images
         run: |
+          ls $HOME
+          ls $HOME/images
+          ls $HOME/
           rm -rf $HOME/images


### PR DESCRIPTION
Fix qcow image removal by aligning the environment with the autorun workflow container. Added directory listing for debugging.